### PR TITLE
fix(glsl-lang-quote): correctly parse #(ident) at line start

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 default-members = [
 	"lang",
 	"lang-pp",

--- a/lang-lexer/src/lib.rs
+++ b/lang-lexer/src/lib.rs
@@ -52,3 +52,40 @@ pub trait LangLexerIterator:
         err: lalrpop_util::ParseError<LexerPosition, Token, Self::Error>,
     ) -> lang_util::error::ParseError<Self::Error>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HASH_IDENT_TEST_CASE: &str = "# (ident) = hello";
+
+    fn test_hash_ident_with_lexer<'i>(lexer: impl LangLexer<'i, Input = &'i str>) {
+        let tokens: Vec<_> = lexer.run(ParseContext::default()).collect();
+        eprintln!("{:#?}", tokens);
+        assert!(tokens.len() > 1);
+    }
+
+    #[cfg(feature = "v2-min")]
+    #[test]
+    fn test_hash_ident_v2_min() {
+        test_hash_ident_with_lexer(v2_min::str::Lexer::new(
+            HASH_IDENT_TEST_CASE,
+            &ParseOptions {
+                allow_rs_ident: true,
+                ..Default::default()
+            },
+        ));
+    }
+
+    #[cfg(feature = "v2-full")]
+    #[test]
+    fn test_hash_ident_v2_full() {
+        test_hash_ident_with_lexer(v2_full::str::Lexer::new(
+            HASH_IDENT_TEST_CASE,
+            &ParseOptions {
+                allow_rs_ident: true,
+                ..Default::default()
+            },
+        ));
+    }
+}

--- a/lang-pp/src/parser/tests.rs
+++ b/lang-pp/src/parser/tests.rs
@@ -267,3 +267,17 @@ fn test_eof() {
     "##]],
     );
 }
+
+#[test]
+fn test_hash_ident() {
+    check(
+        parse("#(ident)"),
+        expect![[r##"
+            ROOT@0..8
+              HASH@0..1 "#"
+              LPAREN@1..2 "("
+              IDENT_KW@2..7 "ident"
+              RPAREN@7..8 ")"
+        "##]],
+    );
+}

--- a/lang-pp/src/processor/nodes.rs
+++ b/lang-pp/src/processor/nodes.rs
@@ -292,8 +292,7 @@ impl VersionProfile {
 
 impl PartialOrd for VersionProfile {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.as_feature_set_size_index()
-            .partial_cmp(&other.as_feature_set_size_index())
+        Some(self.cmp(other))
     }
 }
 

--- a/lang-quote/tests/lib.rs
+++ b/lang-quote/tests/lib.rs
@@ -107,3 +107,21 @@ fn layout_qualifier() {
         layout(std140) struct Q { float f; };
     };
 }
+
+#[test]
+fn statement_var_decl() {
+    let current_mat: ast::Expr =
+        ast::ExprData::Variable(ast::IdentifierData("main".into()).into()).into();
+    let work_var: ast::Expr =
+        ast::ExprData::Variable(ast::IdentifierData("work_var".into()).into()).into();
+    let work_var_ps: ast::Expr =
+        ast::ExprData::Variable(ast::IdentifierData("work_var_ps".into()).into()).into();
+
+    let _ = glsl_statement! {
+        {
+            mat3 mt = #(current_mat);
+            #(work_var.clone()) = mt * #(work_var);
+            #(work_var_ps.clone()) = mt * #(work_var_ps);
+        }
+    };
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.74.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
The preprocessor parser incorrectly assumed a `#` at the start of a line would necessarily start a preprocessor control directive. This adds tests and the fix for forwading this to the later stages.