### PR TITLE
fix(transpiler): append "precision" for precision decl

### DIFF
--- a/lang/src/transpiler/glsl.rs
+++ b/lang/src/transpiler/glsl.rs
@@ -1527,6 +1527,7 @@ where
             show_init_declarator_list(f, list, state)?;
         }
         ast::DeclarationData::Precision(ref qual, ref ty) => {
+            f.write_str("precision ")?;
             show_precision_qualifier(f, qual, state)?;
             f.write_str(" ")?;
             show_type_specifier(f, ty, state)?;


### PR DESCRIPTION
This patch fixes the case "Default Precision Qualifiers", we should append "precision " before the qualifier in this case.