### PR TITLE
fix(pp): add GL_OVR_multiview2 and provide a new method to custom exts

### DIFF
--- a/lang-pp/src/exts.rs
+++ b/lang-pp/src/exts.rs
@@ -46,6 +46,10 @@ impl Registry {
     pub fn get(&self, name: &ExtNameAtom) -> Option<&ExtensionSpec> {
         self.extensions.get(name)
     }
+
+    pub fn add(&mut self, spec: ExtensionSpec) {
+        self.extensions.insert(spec.name.clone(), spec);
+    }
 }
 
 // TODO: Fill registry with extension data from Khronos
@@ -568,6 +572,7 @@ impl Default for Registry {
                     ],
                 ),
                 ExtensionSpec::new(ExtNameAtom::from("GL_OVR_multiview"), vec![]),
+                ExtensionSpec::new(ExtNameAtom::from("GL_OVR_multiview2"), vec![]),
             ]
             .into_iter()
             .map(|spec| (spec.name.clone(), spec))


### PR DESCRIPTION
This PR:

1. adds `GL_OVR_multiview2`
2. adds a new method `add()` on `Registry` to allow developers to add extenisions which is not supported

To repro this case:

```glsl
#extension GL_OVR_multiview2 : enable

void main() { 
  gl_FragColor = vec4(1, 1, 1, 1); 
}
```