### PR TITLE
feat(parser): add type_qualifier only in decls

### DIFF
--- a/lang-quote/src/tokenize.rs
+++ b/lang-quote/src/tokenize.rs
@@ -1117,6 +1117,11 @@ fn tokenize_declaration(d: &ast::Declaration) -> TokenStream {
             let ident = tokenize_identifier(ident);
             quote! { glsl_lang::ast::DeclarationData::Invariant(#ident) }
         }
+
+        ast::DeclarationData::TypeOnly(ref q) => {
+            let q = tokenize_type_qualifier(q);
+            quote! { glsl_lang::ast::DeclarationData::TypeOnly(#q) }
+        }
     };
 
     let span = tokenize_span(&d.span);

--- a/lang-quote/tests/lib.rs
+++ b/lang-quote/tests/lib.rs
@@ -125,3 +125,10 @@ fn statement_var_decl() {
         }
     };
 }
+
+#[test]
+fn typeonly_multiview_qualifier() {
+    let _ = glsl! {
+        layout (num_views = 2) in;
+    };
+}

--- a/lang-types/src/ast.rs
+++ b/lang-types/src/ast.rs
@@ -991,6 +991,8 @@ pub enum DeclarationData {
     Block(Block),
     /// Invariant declaration
     Invariant(Identifier),
+    /// Type-only declaration
+    TypeOnly(TypeQualifier),
 }
 
 impl_node_content! {

--- a/lang/src/parser.lalrpop
+++ b/lang/src/parser.lalrpop
@@ -694,6 +694,7 @@ declaration: ast::Declaration = {
     <l:@L> <p:precision_declaration> ";" <r:@R> => p.spanned(l, r),
     <l:@L> <b:block_declaration> ";"     <r:@R> => ast::DeclarationData::Block(b).spanned(l, r),
     <l:@L> "invariant" <i:identifier> ";" <r:@R> => ast::DeclarationData::Invariant(i).spanned(l, r),
+    <l:@L> <q:type_qualifier> ";" <r:@R> => ast::DeclarationData::TypeOnly(q).spanned(l, r),
 };
 
 function_definition: ast::FunctionDefinition = {

--- a/lang/src/transpiler/glsl.rs
+++ b/lang/src/transpiler/glsl.rs
@@ -1539,6 +1539,9 @@ where
             f.write_char(' ')?;
             show_identifier(f, ident, state)?;
         }
+        ast::DeclarationData::TypeOnly(ref q) => {
+            show_type_qualifier(f, q, state)?;
+        }
     }
 
     state.write_declaration_terminator(f)

--- a/lang/src/visitor.rs
+++ b/lang/src/visitor.rs
@@ -740,6 +740,8 @@ macro_rules! make_host_trait {
             ast::DeclarationData::Block(block) => block.$mthd_name(visitor),
 
             ast::DeclarationData::Invariant(ident) => ident.$mthd_name(visitor),
+
+            ast::DeclarationData::TypeOnly(q) => q.$mthd_name(visitor),
           }
         }
       }


### PR DESCRIPTION
This PR supports parsing the following case:

![image](https://github.com/user-attachments/assets/40970940-d380-48b0-8a58-b59a22818e72)

This supports to parse type_qualifier only declaration such as: `layout (num_views = 2) in;` to be parsed.

Ref: https://registry.khronos.org/OpenGL/specs/es/3.2/GLSL_ES_Specification_3.20.pdf