### PR TITLE
pp: eval and expand #elif only if the last is none

### DIFF
--- a/lang-pp/src/processor/expand.rs
+++ b/lang-pp/src/processor/expand.rs
@@ -407,17 +407,18 @@ impl ExpandOne {
                 let expr = match &directive {
                     Ok(elif_) => {
                         if self.if_stack.if_group_active() {
-                            let (value, error) = if active {
-                                elif_.eval(current_state, &self.location)
+                            if !self.if_stack.none() {
+                                // Always false if the last if state was activated once
+                                false
+                            } else if active {
+                                let (value, error) = elif_.eval(current_state, &self.location);
+                                if let Some(error) = error {
+                                    errors.push(ProcessingErrorKind::DirectiveElif(error));
+                                }
+                                value
                             } else {
-                                (true, None)
-                            };
-
-                            if let Some(error) = error {
-                                errors.push(ProcessingErrorKind::DirectiveElif(error));
+                                true
                             }
-
-                            value
                         } else {
                             // Do not evaluate if the group is not active
                             true

--- a/lang-pp/src/processor/expand/if_stack.rs
+++ b/lang-pp/src/processor/expand/if_stack.rs
@@ -20,6 +20,10 @@ impl IfState {
         }
     }
 
+    pub fn none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+
     pub fn active(&self) -> bool {
         matches!(self, Self::Active { .. })
     }
@@ -93,6 +97,10 @@ impl IfStack {
 
     pub fn active(&self) -> bool {
         self.stack.last().map(|top| top.active()).unwrap_or(true)
+    }
+
+    pub fn none(&self) -> bool {
+        self.stack.last().map(|top| top.none()).unwrap_or(false)
     }
 
     pub fn on_if_like(&mut self, expr: bool) {


### PR DESCRIPTION
This pull request refines the handling of conditional preprocessing directives in the macro expansion logic, specifically improving how `elif` directives are evaluated based on the current state of the `if` stack.

For example:

```glsl
#version 300 es
#define CS1
#define CS2
#define CS3

vec3 test() {
#if defined(CS1)
  return vec3(1.0, 0.0, 0.0);
#elif defined(CS2)
  return vec3(2.0, 0.0, 0.0);
#elif defined(CS3)
  return vec3(3.0, 1.0, 0.0);
#else
  return vec3(0.0, 0.0, 1.0);
#endif
}
```

Without this patch, it will be expanded to:

```glsl
#version 300 es
vec3 test() {
  return vec3(1.0, 0.0, 0.0);
  return vec3(2.0, 0.0, 0.0);
  return vec3(3.0, 1.0, 0.0);
#endif
}
```